### PR TITLE
WIP: deis -> hephy in README and groovy

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,18 +1,18 @@
 
-|![](https://upload.wikimedia.org/wikipedia/commons/thumb/1/17/Warning.svg/156px-Warning.svg.png) | Deis Workflow will soon no longer be maintained.<br />Please [read the announcement](https://deis.com/blog/2017/deis-workflow-final-release/) for more detail. |
+|![](https://upload.wikimedia.org/wikipedia/commons/thumb/1/17/Warning.svg/156px-Warning.svg.png) | Hephy Workflow is coming soon.<br />Please [wait patiently for the announcement](https://teamhephy.com) while we clear our dust. |
 |---:|---|
 | 09/07/2017 | Deis Workflow [v2.18][] final release before entering maintenance mode |
 | 03/01/2018 | End of Workflow maintenance: critical patches no longer merged |
 
-# Deis Workflow Jenkins Jobs
+# Hephy Workflow Jenkins Jobs
 
-Deis (pronounced DAY-iss) Workflow is an open source Platform as a Service (PaaS) that adds a developer-friendly layer to any [Kubernetes](http://kubernetes.io) cluster, making it easy to deploy and manage applications on your own servers.
+Hephy (<strike>pronounced DAY-iss</strike>) Workflow is an open source Platform as a Service (PaaS) that adds a developer-friendly layer to any [Kubernetes](http://kubernetes.io) cluster, making it easy to deploy and manage applications on your own servers.  Hephy is a derivative fork of Deis Workflow v2 PaaS.
 
-For more information about the Deis Workflow, please visit the main project page at https://github.com/deisthree/workflow.
+For more information about the Hephy Workflow, please visit the main project page at https://github.com/teamhephy/workflow.
 
 # About
 
-This repository serves as a central location for [Deis Workflow Jenkins jobs](https://ci.deis.io) represented in [Jenkins Job DSL](https://github.com/jenkinsci/job-dsl-plugin).
+This repository serves as a central location for [Hephy Workflow Jenkins jobs](https://example.com/coming-soon) represented in [Jenkins Job DSL](https://github.com/jenkinsci/job-dsl-plugin).
 
 ## Resources
 
@@ -62,7 +62,7 @@ To do so, one would update/add the appropriate plugin in `build.gradle` and then
 ## Flow
 
 As a standard practice, the initial job will describe the pipeline, in the form of `downstreamParameterized` steps
-that follow the main steps of the job itself.  See the [Workflow component job](https://github.com/deisthree/jenkins-jobs/blob/master/jobs/component_jobs.groovy) as an example.  Most of the downstream jobs are then set up to only execute their specific job logic, and not add further downstream dependencies that might be different from what the initial job specifies.
+that follow the main steps of the job itself.  See the [Workflow component job](https://github.com/teamhephy/jenkins-jobs/blob/master/jobs/component_jobs.groovy) as an example.  Most of the downstream jobs are then set up to only execute their specific job logic, and not add further downstream dependencies that might be different from what the initial job specifies.
 
 (The pipelines below can also be found in their original `.monopic` format if needing to change/update.)
 
@@ -288,4 +288,4 @@ that follow the main steps of the job itself.  See the [Workflow component job](
 [bats]: https://github.com/sstephenson/bats
 [shellcheck]: https://github.com/koalaman/shellcheck
 [gradle-prereqs]: https://docs.gradle.org/current/userguide/installation.html#sec:prerequisites
-[v2.18]: https://github.com/deisthree/workflow/releases/tag/v2.18.0
+[v2.18]: https://github.com/teamhephy/workflow/releases/tag/v2.18.0

--- a/bash/scripts/build_darwin_cli_binary.sh
+++ b/bash/scripts/build_darwin_cli_binary.sh
@@ -18,13 +18,13 @@ build-darwin-cli-binary() {
 
   GIT_TAG="$(git describe --abbrev=0 --tags)"
   DIST_DIR="_dist"
-  GO_LDFLAGS="-X github.com/deis/workflow-cli/version.Version=${GIT_TAG}"
+  GO_LDFLAGS="-X github.com/hephyci-admin/workflow-cli/version.Version=${GIT_TAG}"
   case "${make_target}" in
     "build-tag")
-    go build -a -ldflags "${GO_LDFLAGS}" -o "${DIST_DIR}/${GIT_TAG}/deis-${GIT_TAG}-darwin-amd64" .
+    go build -a -ldflags "${GO_LDFLAGS}" -o "${DIST_DIR}/${GIT_TAG}/hephy-${GIT_TAG}-darwin-amd64" .
     ;;
     "build-stable")
-    go build -a -ldflags "${GO_LDFLAGS}" -o "${DIST_DIR}/deis-stable-darwin-amd64" .
+    go build -a -ldflags "${GO_LDFLAGS}" -o "${DIST_DIR}/hephy-stable-darwin-amd64" .
     ;;
   esac
 }

--- a/bash/scripts/find_required_commits.sh
+++ b/bash/scripts/find_required_commits.sh
@@ -9,7 +9,7 @@ find-required-commits() {
 
   # Looks specifically for matches of '[rR]equires <repo>#<pr_number>',
   # e.g., "requires builder#123, Requires router#567"
-  reqs=$(echo "${commit_description}" | grep -o "[Rr]equires \(deis\/\)\?[-a-z0-9]*#[0-9]\{1,9\}" | grep -o "[-a-z0-9]*#[0-9]\{1,9\}") || true
+  reqs=$(echo "${commit_description}" | grep -o "[Rr]equires \(teamhephy\/\)\?[-a-z0-9]*#[0-9]\{1,9\}" | grep -o "[-a-z0-9]*#[0-9]\{1,9\}") || true
 
   if [ "${reqs}" != "" ]; then
     # split on whitespace into array of '<repo>#<pr_number>' values
@@ -44,8 +44,8 @@ get-pr-commits() {
 
   resp=$(curl \
   -sSL \
-  --user deis-admin:"${GITHUB_ACCESS_TOKEN}" \
-  "https://api.github.com/repos/deis/${repo_name}/pulls/${pr_number}/commits")
+  --user hephyci-admin:"${GITHUB_ACCESS_TOKEN}" \
+  "https://api.github.com/repos/hephyci-admin/${repo_name}/pulls/${pr_number}/commits")
 
   echo "${resp}" >&2
   echo "${resp}" | jq '.[].sha'

--- a/bash/scripts/get_actual_commit.sh
+++ b/bash/scripts/get_actual_commit.sh
@@ -28,8 +28,8 @@ get-pr-commit() {
   # curl GH api to derive actual pr commit for reporting status and Docker image tagging
   resp=$(curl \
   -sSL \
-  --user deis-admin:"${GITHUB_ACCESS_TOKEN}" \
-  "https://api.github.com/repos/deis/${repo_name}/commits/${commit}")
+  --user hephyci-admin:"${GITHUB_ACCESS_TOKEN}" \
+  "https://api.github.com/repos/hephyci-admin/${repo_name}/commits/${commit}")
 
   commit_pattern='[a-f0-9]\{40\}'
   echo "${resp}" \

--- a/bash/scripts/get_latest_component_release.sh
+++ b/bash/scripts/get_latest_component_release.sh
@@ -11,7 +11,7 @@ get-latest-component-release() {
     component_to_curl="grafana"
   fi
 
-  wfm_api_url="https://versions.teamhephy.info/v3/versions/stable/hephy-${component_to_curl}/latest"
+  wfm_api_url="http://versions.teamhephy.info/v3/versions/stable/hephy-${component_to_curl}/latest"
   echo "Getting latest ${component} release via url: ${wfm_api_url}" >&2
 
   latest_release="$(curl -sf "${wfm_api_url}" | jq '.version.version' | tr -d '"')"

--- a/bash/scripts/get_latest_component_release.sh
+++ b/bash/scripts/get_latest_component_release.sh
@@ -11,7 +11,7 @@ get-latest-component-release() {
     component_to_curl="grafana"
   fi
 
-  wfm_api_url="https://versions.deis.com/v3/versions/stable/deis-${component_to_curl}/latest"
+  wfm_api_url="https://versions.teamhephy.info/v3/versions/stable/hephy-${component_to_curl}/latest"
   echo "Getting latest ${component} release via url: ${wfm_api_url}" >&2
 
   latest_release="$(curl -sf "${wfm_api_url}" | jq '.version.version' | tr -d '"')"

--- a/bash/scripts/get_latest_tag.sh
+++ b/bash/scripts/get_latest_tag.sh
@@ -15,7 +15,7 @@ get-latest-tag() {
   fi
 
   # grab latest tag from GH
-  latest_tag="$(curl -sSf "https://api.github.com/repos/deis/${component}/releases/latest" | jq '.tag_name' | tr -d '"')"
+  latest_tag="$(curl -sSf "https://api.github.com/repos/hephyci-admin/${component}/releases/latest" | jq '.tag_name' | tr -d '"')"
 
   # If tag not latest, bail out
   if [ "${tag}" != "${latest_tag}" ]; then

--- a/bash/scripts/helm_chart_actions.sh
+++ b/bash/scripts/helm_chart_actions.sh
@@ -2,7 +2,7 @@
 
 set -eo pipefail
 
-export DEIS_CHARTS_BASE_URL="https://charts.deis.com"
+export DEIS_CHARTS_BASE_URL="https://charts.teamhephy.info"
 
 # sign-and-package-helm-chart signs and packages the helm chart provided by chart,
 # expecting a signing key passphrase in SIGNING_KEY_PASSPHRASE.
@@ -19,7 +19,7 @@ sign-and-package-helm-chart() {
     return 1
   fi
 
-  signing_key="${SIGNING_KEY:-Deis, Inc. (Helm chart signing key)}"
+  signing_key="${SIGNING_KEY:-Team Hephy (Helm chart signing key)}"
   keyring="${KEYRING:-${JENKINS_HOME}/.gnupg/secring.gpg}"
 
   echo "Signing packaged chart '${chart}' with key '${signing_key}' from keyring '${keyring}'..." >&2
@@ -134,8 +134,8 @@ update-chart() {
     ## make component chart updates
     if [ "${chart_repo}" == "${chart}" ]; then
       ## chart repo is production repo; update values appropriately
-      # update all org values to "deis"
-      perl -i -0pe 's/"deisci"/"deis"/g' "${chart}"/values.yaml
+      # update all org values to "teamhephy"
+      perl -i -0pe 's/"hephyci"/"teamhephy"/g' "${chart}"/values.yaml
       # update the image pull policy to "IfNotPresent"
       perl -i -0pe 's/"Always"/"IfNotPresent"/g' "${chart}"/values.yaml
       # update the dockerTag value to chart_version
@@ -207,8 +207,8 @@ update-chart() {
     # if chart repo name does not match chart (i.e. workflow(-dev/-pr/-staging) != workflow), consider it non-production
     if [ "${chart_repo}" != "${chart}" ]; then
       # modify workflow-manager/doctor urls in values.yaml to point to staging
-      perl -i -0pe "s/versions.deis/versions-staging.deis/g" "${chart}"/values.yaml
-      perl -i -0pe "s/doctor.deis/doctor-staging.deis/g" "${chart}"/values.yaml
+      perl -i -0pe "s/versions.teamhephy/versions-staging.teamhephy/g" "${chart}"/values.yaml
+      perl -i -0pe "s/doctor.teamhephy/doctor-staging.teamhephy/g" "${chart}"/values.yaml
     fi
 
     # set WORKFLOW_TAG for downstream e2e job to read from

--- a/bash/scripts/helm_chart_actions.sh
+++ b/bash/scripts/helm_chart_actions.sh
@@ -2,7 +2,7 @@
 
 set -eo pipefail
 
-export DEIS_CHARTS_BASE_URL="https://charts.teamhephy.info"
+export DEIS_CHARTS_BASE_URL="http://charts.teamhephy.info"
 
 # sign-and-package-helm-chart signs and packages the helm chart provided by chart,
 # expecting a signing key passphrase in SIGNING_KEY_PASSPHRASE.

--- a/bash/scripts/locate_release_candidate.sh
+++ b/bash/scripts/locate_release_candidate.sh
@@ -8,7 +8,7 @@ locate-release-candidate() {
   local tag="${3}"
 
   component_env_var="$(echo "${component}" | perl -ne 'print uc' | sed 's/-/_/g')"_SHA
-  candidate_image=quay.io/deis/"${component}":git-"${commit:0:7}"
+  candidate_image=quay.io/hephyci/"${component}":git-"${commit:0:7}"
 
   if ! docker pull "${candidate_image}"; then
     echo "Release candidate '${candidate_image}' cannot be located; exiting." 1>&2

--- a/bash/scripts/promote_component.sh
+++ b/bash/scripts/promote_component.sh
@@ -18,8 +18,8 @@ promote-component() {
   local image_name_and_tag="${component}:git-${commit:0:7}"
 
   # promote to dockerhub
-  local original_image=deisci/"${image_name_and_tag}"
-  local promoted_image=deis/"${image_name_and_tag}"
+  local original_image=hephyci/"${image_name_and_tag}"
+  local promoted_image=hephy/"${image_name_and_tag}"
 
   echo "Promoting ${original_image} to ${promoted_image}"
 

--- a/bash/scripts/retag_release_candidate.sh
+++ b/bash/scripts/retag_release_candidate.sh
@@ -9,7 +9,7 @@ main() {
 retag-release-candidate() {
   local candidate="${1}"
   local commit="${2}"
-  local image_name="deis/${candidate}"
+  local image_name="hephy/${candidate}"
 
   # release to dockerhub
   local candidate_image="${image_name}":git-"${commit:0:7}"

--- a/bash/scripts/run_e2e.sh
+++ b/bash/scripts/run_e2e.sh
@@ -19,7 +19,7 @@ run-e2e() {
   local image="${E2E_RUNNER_IMAGE}"
   if [ -n "${E2E_RUNNER_SHA}" ]; then
     image_tag="git-${E2E_RUNNER_SHA:0:7}"
-    image="quay.io/deisci/e2e-runner:${image_tag}"
+    image="quay.io/hephyci/e2e-runner:${image_tag}"
   fi
 
   docker pull "${image}" # bust the cache as tag may be canary

--- a/bash/scripts/update_commit_status.sh
+++ b/bash/scripts/update_commit_status.sh
@@ -20,7 +20,7 @@ update-commit-status() {
 
   curl \
     -sSL \
-    --user deis-admin:"${GITHUB_ACCESS_TOKEN}" \
+    --user hephyci-admin:"${GITHUB_ACCESS_TOKEN}" \
     --data "${data}" \
-    "https://api.github.com/repos/deis/${repo_name}/statuses/${git_commit}"
+    "https://api.github.com/repos/hephyci-admin/${repo_name}/statuses/${git_commit}"
 }

--- a/build.gradle
+++ b/build.gradle
@@ -11,9 +11,10 @@ sourceSets {
 }
 
 repositories {
-    mavenCentral()
-    jcenter()
+    maven { url 'http://bits.netbeans.org/maven2' }
     maven { url 'http://repo.jenkins-ci.org/releases/' }
+    jcenter()
+    mavenCentral()
 }
 
 configurations {
@@ -37,7 +38,7 @@ dependencies {
     // Job DSL plugin including plugin dependencies
     testCompile "${defaultJenkinsPluginHost}:job-dsl:${jobDslVersion}"
     testCompile "${defaultJenkinsPluginHost}:job-dsl:${jobDslVersion}@jar"
-    testCompile "${defaultJenkinsPluginHost}:structs:1.3@jar"
+    testCompile "${defaultJenkinsPluginHost}:structs:1.14@jar"
     testCompile "${defaultJenkinsPluginHost}:cloudbees-folder:5.12@jar"
 
     // plugins to install in test instance

--- a/common.groovy
+++ b/common.groovy
@@ -31,8 +31,8 @@ defaults = [
     accessTokenCredentialsID: 'f19ff3f0-f660-4fda-80ae-c31c246fda55',
   ],
   azure: [
-    storageAccount: 'f2a28186-f3e1-4a51-9d15-e1646bdf34e6',
-    storageAccountKeyID: 'c9cad0b0-53dd-4d38-a832-c4b29aeaf49b',
+    storageAccount: '7f71d198-f5d7-4ded-9b2b-58280ce69ef2',
+    storageAccountKeyID: '7ba177e3-b6de-4dbc-99f2-4bacf1a31cc0',
   ],
   statusesToNotify: ['SUCCESS', 'FAILURE'],
   "e2eRunner": [ provider: 'google', ],

--- a/common.groovy
+++ b/common.groovy
@@ -3,7 +3,7 @@ if (!new File("${workspace}/common.groovy").canRead()) { workspace = "${WORKSPAC
 evaluate(new File("${workspace}/repo.groovy"))
 
 defaults = [
-  signingNode: ['deis-signatory'],
+  signingNode: ['hephy-signatory'],
   tmpPath: '/tmp/${JOB_NAME}/${BUILD_NUMBER}',
   envFile: '/tmp/${JOB_NAME}/${BUILD_NUMBER}/env.properties',
   daysToKeep: 14,
@@ -18,7 +18,7 @@ defaults = [
     release: 'stable',
   ],
   slack: [
-    teamDomain: 'deis',
+    teamDomain: 'teamhephy',
     channel: '#testing',
     webhookURL: 'a53b3a9e-d649-4cff-9997-6c24f07743c8',
   ],
@@ -26,7 +26,7 @@ defaults = [
     version: 'v2.6.1',
   ],
   github: [
-    username: 'deis-admin',
+    username: 'teamhephy-admin',
     credentialsID: 'a2eef59f-cede-4190-a096-ea65722e2b83',
     accessTokenCredentialsID: '393d5b89-9da5-410a-a476-94c9f4325217',
   ],

--- a/common.groovy
+++ b/common.groovy
@@ -27,8 +27,8 @@ defaults = [
   ],
   github: [
     username: 'teamhephy-admin',
-    credentialsID: 'a2eef59f-cede-4190-a096-ea65722e2b83',
-    accessTokenCredentialsID: '393d5b89-9da5-410a-a476-94c9f4325217',
+    credentialsID: 'be091a9e-1bcb-4149-91a7-fc0c94d4d553',
+    accessTokenCredentialsID: 'f19ff3f0-f660-4fda-80ae-c31c246fda55',
   ],
   azure: [
     storageAccount: 'f2a28186-f3e1-4a51-9d15-e1646bdf34e6',

--- a/common.groovy
+++ b/common.groovy
@@ -20,7 +20,7 @@ defaults = [
   slack: [
     teamDomain: 'teamhephy',
     channel: '#testing',
-    webhookURL: 'a53b3a9e-d649-4cff-9997-6c24f07743c8',
+    webhookURL: '95f29b21-3cd5-44b3-9a7b-c0b8bbf77b5d',
   ],
   helm: [
     version: 'v2.6.1',

--- a/common.groovy
+++ b/common.groovy
@@ -23,7 +23,7 @@ defaults = [
     webhookURL: '95f29b21-3cd5-44b3-9a7b-c0b8bbf77b5d',
   ],
   helm: [
-    version: 'v2.6.1',
+    version: 'v2.8.2',
   ],
   github: [
     username: 'teamhephy-admin',

--- a/jobs/apptypes_test.groovy
+++ b/jobs/apptypes_test.groovy
@@ -24,7 +24,7 @@ job(name) {
 
   parameters {
     stringParam('RELEASE', "dev", "Release string for resolving workflow-[release](-e2e) charts")
-    stringParam('E2E_RUNNER_IMAGE', 'quay.io/kingdonb/e2e-runner:canary', "The e2e-runner image")
+    stringParam('E2E_RUNNER_IMAGE', 'quay.io/hephyci/e2e-runner:canary', "The e2e-runner image")
     stringParam('E2E_DIR', '/home/jenkins/workspace/$JOB_NAME/$BUILD_NUMBER', "Directory for storing workspace files")
     stringParam('E2E_DIR_LOGS', '${E2E_DIR}/logs', "Directory for storing logs. This directory is mounted into the e2e-runner container")
     stringParam('CLOUD_PROVIDER', defaults.e2eRunner.provider)

--- a/jobs/apptypes_test.groovy
+++ b/jobs/apptypes_test.groovy
@@ -12,7 +12,7 @@ job(name) {
   scm {
     git {
       remote {
-        github("deis/e2e-runner")
+        github("teamhephy/e2e-runner")
       }
       branch('master')
     }
@@ -24,7 +24,7 @@ job(name) {
 
   parameters {
     stringParam('RELEASE', "dev", "Release string for resolving workflow-[release](-e2e) charts")
-    stringParam('E2E_RUNNER_IMAGE', 'quay.io/deisci/e2e-runner:canary', "The e2e-runner image")
+    stringParam('E2E_RUNNER_IMAGE', 'quay.io/kingdonb/e2e-runner:canary', "The e2e-runner image")
     stringParam('E2E_DIR', '/home/jenkins/workspace/$JOB_NAME/$BUILD_NUMBER', "Directory for storing workspace files")
     stringParam('E2E_DIR_LOGS', '${E2E_DIR}/logs', "Directory for storing logs. This directory is mounted into the e2e-runner container")
     stringParam('CLOUD_PROVIDER', defaults.e2eRunner.provider)

--- a/jobs/clusterator_jobs.groovy
+++ b/jobs/clusterator_jobs.groovy
@@ -4,7 +4,7 @@ evaluate(new File("${workspace}/common.groovy"))
 
 job("clusterator-create") {
   disabled() // delete this file when ready to fully remove job
-  description "Create a set number of clusters in the deis leasable project. This job runs Monday-Friday at 7AM."
+  description "Create a set number of clusters in the hephy leasable project. This job runs Monday-Friday at 7AM."
 
   logRotator {
     daysToKeep defaults.daysToKeep
@@ -40,14 +40,14 @@ job("clusterator-create") {
       -e NUM_NODES="\${NUM_NODES}" \
       -e MACHINE_TYPE="\${MACHINE_TYPE}" \
       -e VERSION="\${VERSION}" \
-      quay.io/deisci/clusterator:git-b1810a5 create
+      quay.io/kingdonb/clusterator:git-b1810a5 create
     """.stripIndent().trim()
   }
 }
 
 job("clusterator-delete") {
   disabled() // delete this file when ready to fully remove job
-  description "Clean up clusters in the deis leasable project. This job runs Monday-Friday at 7PM."
+  description "Clean up clusters in the hephy leasable project. This job runs Monday-Friday at 7PM."
 
   logRotator {
     daysToKeep defaults.daysToKeep
@@ -70,7 +70,7 @@ job("clusterator-delete") {
       #!/usr/bin/env bash
 
       set -eo pipefail
-      docker run -e GCLOUD_CREDENTIALS="\${GCLOUD_CREDENTIALS}" quay.io/deisci/clusterator:git-b1810a5 delete
+      docker run -e GCLOUD_CREDENTIALS="\${GCLOUD_CREDENTIALS}" quay.io/kingdonb/clusterator:git-b1810a5 delete
     """.stripIndent().trim()
   }
 }

--- a/jobs/clusterator_jobs.groovy
+++ b/jobs/clusterator_jobs.groovy
@@ -40,7 +40,7 @@ job("clusterator-create") {
       -e NUM_NODES="\${NUM_NODES}" \
       -e MACHINE_TYPE="\${MACHINE_TYPE}" \
       -e VERSION="\${VERSION}" \
-      quay.io/kingdonb/clusterator:git-4097125 create
+      quay.io/hephyci/clusterator:git-4097125 create
     """.stripIndent().trim()
   }
 }

--- a/jobs/clusterator_jobs.groovy
+++ b/jobs/clusterator_jobs.groovy
@@ -40,7 +40,7 @@ job("clusterator-create") {
       -e NUM_NODES="\${NUM_NODES}" \
       -e MACHINE_TYPE="\${MACHINE_TYPE}" \
       -e VERSION="\${VERSION}" \
-      quay.io/kingdonb/clusterator:git-d863fa2 create
+      quay.io/kingdonb/clusterator:git-f307131 create
     """.stripIndent().trim()
   }
 }
@@ -70,7 +70,7 @@ job("clusterator-delete") {
       #!/usr/bin/env bash
 
       set -eo pipefail
-      docker run -e GCLOUD_CREDENTIALS="\${GCLOUD_CREDENTIALS}" quay.io/kingdonb/clusterator:git-d863fa2 delete
+      docker run -e GCLOUD_CREDENTIALS="\${GCLOUD_CREDENTIALS}" quay.io/kingdonb/clusterator:git-f307131 delete
     """.stripIndent().trim()
   }
 }

--- a/jobs/clusterator_jobs.groovy
+++ b/jobs/clusterator_jobs.groovy
@@ -70,7 +70,7 @@ job("clusterator-delete") {
       #!/usr/bin/env bash
 
       set -eo pipefail
-      docker run -e GCLOUD_CREDENTIALS="\${GCLOUD_CREDENTIALS}" quay.io/kingdonb/clusterator:git-f307131 delete
+      docker run -e GCLOUD_CREDENTIALS="\${GCLOUD_CREDENTIALS}" quay.io/hephyci/clusterator:git-4097125 delete
     """.stripIndent().trim()
   }
 }

--- a/jobs/clusterator_jobs.groovy
+++ b/jobs/clusterator_jobs.groovy
@@ -40,7 +40,7 @@ job("clusterator-create") {
       -e NUM_NODES="\${NUM_NODES}" \
       -e MACHINE_TYPE="\${MACHINE_TYPE}" \
       -e VERSION="\${VERSION}" \
-      quay.io/kingdonb/clusterator:git-f307131 create
+      quay.io/kingdonb/clusterator:git-4097125 create
     """.stripIndent().trim()
   }
 }

--- a/jobs/clusterator_jobs.groovy
+++ b/jobs/clusterator_jobs.groovy
@@ -18,7 +18,7 @@ job("clusterator-create") {
     stringParam('NUMBER_OF_CLUSTERS', '1', 'Number of clusters to create at 1 time')
     stringParam('NUM_NODES', '5', 'Number of nodes in each cluster')
     stringParam('MACHINE_TYPE', 'n1-standard-4', 'Node type')
-    stringParam('VERSION', '1.7', 'The version of kubernetes to use.')
+    stringParam('VERSION', '1.8', 'The version of kubernetes to use.')
   }
 
   wrappers {

--- a/jobs/clusterator_jobs.groovy
+++ b/jobs/clusterator_jobs.groovy
@@ -18,7 +18,7 @@ job("clusterator-create") {
     stringParam('NUMBER_OF_CLUSTERS', '1', 'Number of clusters to create at 1 time')
     stringParam('NUM_NODES', '5', 'Number of nodes in each cluster')
     stringParam('MACHINE_TYPE', 'n1-standard-4', 'Node type')
-    stringParam('VERSION', '1.8', 'The version of kubernetes to use.')
+    stringParam('VERSION', '1.8.8', 'The version of kubernetes to use.')
   }
 
   wrappers {

--- a/jobs/clusterator_jobs.groovy
+++ b/jobs/clusterator_jobs.groovy
@@ -40,7 +40,7 @@ job("clusterator-create") {
       -e NUM_NODES="\${NUM_NODES}" \
       -e MACHINE_TYPE="\${MACHINE_TYPE}" \
       -e VERSION="\${VERSION}" \
-      quay.io/kingdonb/clusterator:git-b1810a5 create
+      quay.io/kingdonb/clusterator:git-d863fa2 create
     """.stripIndent().trim()
   }
 }
@@ -70,7 +70,7 @@ job("clusterator-delete") {
       #!/usr/bin/env bash
 
       set -eo pipefail
-      docker run -e GCLOUD_CREDENTIALS="\${GCLOUD_CREDENTIALS}" quay.io/kingdonb/clusterator:git-b1810a5 delete
+      docker run -e GCLOUD_CREDENTIALS="\${GCLOUD_CREDENTIALS}" quay.io/kingdonb/clusterator:git-d863fa2 delete
     """.stripIndent().trim()
   }
 }

--- a/jobs/clusterator_jobs.groovy
+++ b/jobs/clusterator_jobs.groovy
@@ -15,10 +15,10 @@ job("clusterator-create") {
   }
 
   parameters {
-    stringParam('NUMBER_OF_CLUSTERS', '2', 'Number of clusters to create at 1 time')
+    stringParam('NUMBER_OF_CLUSTERS', '1', 'Number of clusters to create at 1 time')
     stringParam('NUM_NODES', '5', 'Number of nodes in each cluster')
     stringParam('MACHINE_TYPE', 'n1-standard-4', 'Node type')
-    stringParam('VERSION', '', 'The version of kubernetes to use.')
+    stringParam('VERSION', '1.7', 'The version of kubernetes to use.')
   }
 
   wrappers {

--- a/jobs/clusterator_jobs.groovy
+++ b/jobs/clusterator_jobs.groovy
@@ -25,7 +25,7 @@ job("clusterator-create") {
     timestamps()
     colorizeOutput 'xterm'
     credentialsBinding {
-      string("GCLOUD_CREDENTIALS", "15122437-45b8-48ac-bb84-652394c8a927")
+      string("GCLOUD_CREDENTIALS", "7d1ea459-f250-4346-8174-3319b2ec4c20")
     }
   }
 
@@ -61,7 +61,7 @@ job("clusterator-delete") {
     timestamps()
     colorizeOutput 'xterm'
     credentialsBinding {
-      string("GCLOUD_CREDENTIALS", "15122437-45b8-48ac-bb84-652394c8a927")
+      string("GCLOUD_CREDENTIALS", "7d1ea459-f250-4346-8174-3319b2ec4c20")
     }
   }
 

--- a/jobs/component_chart_publish.groovy
+++ b/jobs/component_chart_publish.groovy
@@ -85,7 +85,7 @@ repos.each { Map repo ->
           string("AZURE_STORAGE_KEY", defaults.azure.storageAccountKeyID)
           string("GITHUB_ACCESS_TOKEN", defaults.github.accessTokenCredentialsID)
           string("SLACK_INCOMING_WEBHOOK_URL", defaults.slack.webhookURL)
-          string("SIGNING_KEY_PASSPHRASE", '3963b12b-bad3-429b-b1e5-e047a159bf02')
+          string("SIGNING_KEY_PASSPHRASE", '34783e47-b172-4227-877f-acbffb335ab7')
         }
       }
 

--- a/jobs/component_chart_publish.groovy
+++ b/jobs/component_chart_publish.groovy
@@ -13,7 +13,7 @@ repos.each { Map repo ->
       scm {
         git {
           remote {
-            github("deis/${repo.name}")
+            github("teamhephy/${repo.name}")
             credentials(defaults.github.credentialsID)
           }
           branch('master')
@@ -98,7 +98,7 @@ repos.each { Map repo ->
             # checkout PR commit if repo_type 'pr' and value of commit env var non-null
             if [ "\${CHART_REPO_TYPE}" == 'pr' ] && [ -n "\${${repo.commitEnvVar}}" ]; then
               echo "Fetching PR changes from repo '${repo.name}' at commit \${${repo.commitEnvVar}}" 1>&2
-              git fetch -q --tags --progress https://github.com/deisthree/${repo.name}.git +refs/pull/*:refs/remotes/origin/pr/*
+              git fetch -q --tags --progress https://github.com/teamhephy/${repo.name}.git +refs/pull/*:refs/remotes/origin/pr/*
               git checkout "\${${repo.commitEnvVar}}"
             fi
 

--- a/jobs/component_jobs.groovy
+++ b/jobs/component_jobs.groovy
@@ -90,10 +90,10 @@ repos.each { Map repo ->
         }
 
         parameters {
-          stringParam('DOCKER_USERNAME', 'hephybot', 'Docker Hub account name')
-          stringParam('DOCKER_EMAIL', 'dummy-address@teamhephy.com', 'Docker Hub email address')
-          stringParam('QUAY_USERNAME', 'hephyci+jenkins', 'Quay account name')
-          stringParam('QUAY_EMAIL', 'team+jenkins@teamhephy.com', 'Quay email address')
+          stringParam('DOCKER_USERNAME', 'hephyci', 'Docker Hub account name')
+          stringParam('DOCKER_EMAIL', 'kingdon@teamhephy.com', 'Docker Hub email address')
+          stringParam('QUAY_USERNAME', 'hephyci', 'Quay account name')
+          stringParam('QUAY_EMAIL', 'team@teamhephy.com', 'Quay email address')
           stringParam('sha1', 'master', 'Specific Git SHA to test')
         }
 
@@ -105,8 +105,8 @@ repos.each { Map repo ->
           timestamps()
           colorizeOutput 'xterm'
           credentialsBinding {
-            string("DOCKER_PASSWORD", "0d1f268f-407d-4cd9-a3c2-0f9671df0104")
-            string("QUAY_PASSWORD", "c67dc0a1-c8c4-4568-a73d-53ad8530ceeb")
+            string("DOCKER_PASSWORD", "171dca49-defe-44a9-8d31-b66f69509133")
+            string("QUAY_PASSWORD", "40ea7a06-8e1d-4d09-81be-45f0ce07ce27")
             string("GITHUB_ACCESS_TOKEN", defaults.github.accessTokenCredentialsID)
             string("SLACK_INCOMING_WEBHOOK_URL", defaults.slack.webhookURL)
             if (repo.tokens?.codecov) {

--- a/jobs/component_jobs.groovy
+++ b/jobs/component_jobs.groovy
@@ -66,7 +66,7 @@ repos.each { Map repo ->
 
         if (isPR) { // set up GitHubPullRequest build trigger
           triggers {
-            pullRequest {
+            githubPullRequest {
               admin('teamhephy-admin')
               cron('H/5 * * * *')
               useGitHubHooks()

--- a/jobs/component_jobs.groovy
+++ b/jobs/component_jobs.groovy
@@ -20,7 +20,7 @@ repos.each { Map repo ->
         scm {
           git {
             remote {
-              github("deis/${repo.name}")
+              github("teamhephy/${repo.name}")
               credentials(defaults.github.credentialsID)
               if (isPR) {
                 refspec('+refs/pull/*:refs/remotes/origin/pr/*')
@@ -67,11 +67,11 @@ repos.each { Map repo ->
         if (isPR) { // set up GitHubPullRequest build trigger
           triggers {
             pullRequest {
-              admin('deis-admin')
+              admin('teamhephy-admin')
               cron('H/5 * * * *')
               useGitHubHooks()
               triggerPhrase('OK to test')
-              orgWhitelist(['deis'])
+              orgWhitelist(['teamhephy'])
               allowMembersOfWhitelistedOrgsAsAdmin()
               // this plugin will update PR status no matter what,
               // so until we fix this, here are our default messages:
@@ -90,10 +90,10 @@ repos.each { Map repo ->
         }
 
         parameters {
-          stringParam('DOCKER_USERNAME', 'deisbot', 'Docker Hub account name')
-          stringParam('DOCKER_EMAIL', 'dummy-address@deis.com', 'Docker Hub email address')
-          stringParam('QUAY_USERNAME', 'deisci+jenkins', 'Quay account name')
-          stringParam('QUAY_EMAIL', 'deisci+jenkins@deis.com', 'Quay email address')
+          stringParam('DOCKER_USERNAME', 'hephybot', 'Docker Hub account name')
+          stringParam('DOCKER_EMAIL', 'dummy-address@teamhephy.com', 'Docker Hub email address')
+          stringParam('QUAY_USERNAME', 'hephyci+jenkins', 'Quay account name')
+          stringParam('QUAY_EMAIL', 'team+jenkins@teamhephy.com', 'Quay email address')
           stringParam('sha1', 'master', 'Specific Git SHA to test')
         }
 
@@ -148,7 +148,7 @@ repos.each { Map repo ->
 
               ## Build and Push Images
               # (Some repo 'test' targets depend on `make docker-build` be run before)
-              export IMAGE_PREFIX=deisci VERSION="git-\${git_commit:0:7}"
+              export IMAGE_PREFIX=kingdonb VERSION="git-\${git_commit:0:7}"
 
               docker login -e="\$DOCKER_EMAIL" -u="\$DOCKER_USERNAME" -p="\$DOCKER_PASSWORD"
               # build once with "docker --pull --no-cache" to avoid stale layers

--- a/jobs/component_jobs.groovy
+++ b/jobs/component_jobs.groovy
@@ -148,7 +148,7 @@ repos.each { Map repo ->
 
               ## Build and Push Images
               # (Some repo 'test' targets depend on `make docker-build` be run before)
-              export IMAGE_PREFIX=kingdonb VERSION="git-\${git_commit:0:7}"
+              export IMAGE_PREFIX=hephyci VERSION="git-\${git_commit:0:7}"
 
               docker login -e="\$DOCKER_EMAIL" -u="\$DOCKER_USERNAME" -p="\$DOCKER_PASSWORD"
               # build once with "docker --pull --no-cache" to avoid stale layers

--- a/jobs/component_promote.groovy
+++ b/jobs/component_promote.groovy
@@ -38,10 +38,10 @@ job('component-promote') {
   }
 
   parameters {
-    stringParam('DOCKER_USERNAME', 'hephybot', 'Docker Hub account name')
-    stringParam('DOCKER_EMAIL', 'dummy-address@teamhephy.com', 'Docker Hub email address')
-    stringParam('QUAY_USERNAME', 'hephyci+jenkins', 'Quay account name')
-    stringParam('QUAY_EMAIL', 'team+jenkins@teamhephy.com', 'Quay email address')
+    stringParam('DOCKER_USERNAME', 'hephyci', 'Docker Hub account name')
+    stringParam('DOCKER_EMAIL', 'kingdon@teamhephy.com', 'Docker Hub email address')
+    stringParam('QUAY_USERNAME', 'hephyci', 'Quay account name')
+    stringParam('QUAY_EMAIL', 'team@teamhephy.com', 'Quay email address')
     stringParam('COMPONENT_NAME', '', 'Component name')
     stringParam('COMPONENT_SHA', '', 'Commit sha used for image tag')
     stringParam('UPSTREAM_SLACK_CHANNEL', defaults.slack.channel, "Upstream Slack channel")
@@ -53,8 +53,8 @@ job('component-promote') {
     colorizeOutput 'xterm'
     credentialsBinding {
       string("GITHUB_ACCESS_TOKEN", defaults.github.accessTokenCredentialsID)
-      string("DOCKER_PASSWORD", "0d1f268f-407d-4cd9-a3c2-0f9671df0104")
-      string("QUAY_PASSWORD", "8317a529-10f7-40b5-abd4-a42f242f22f0")
+      string("DOCKER_PASSWORD", "171dca49-defe-44a9-8d31-b66f69509133")
+      string("QUAY_PASSWORD", "40ea7a06-8e1d-4d09-81be-45f0ce07ce27")
       string("SLACK_INCOMING_WEBHOOK_URL", defaults.slack.webhookURL)
     }
   }

--- a/jobs/component_promote.groovy
+++ b/jobs/component_promote.groovy
@@ -4,7 +4,7 @@ evaluate(new File("${workspace}/common.groovy"))
 
 job('component-promote') {
   description """
-    Promotes a component image to the production 'deis' registry org on e2e success after a merge to master
+    Promotes a component image to the production 'kingdonb' registry org on e2e success after a merge to master
   """.stripIndent().trim()
 
 
@@ -38,10 +38,10 @@ job('component-promote') {
   }
 
   parameters {
-    stringParam('DOCKER_USERNAME', 'deisbot', 'Docker Hub account name')
-    stringParam('DOCKER_EMAIL', 'dummy-address@deis.com', 'Docker Hub email address')
-    stringParam('QUAY_USERNAME', 'deis+jenkins', 'Quay account name')
-    stringParam('QUAY_EMAIL', 'deis+jenkins@deis.com', 'Quay email address')
+    stringParam('DOCKER_USERNAME', 'hephybot', 'Docker Hub account name')
+    stringParam('DOCKER_EMAIL', 'dummy-address@teamhephy.com', 'Docker Hub email address')
+    stringParam('QUAY_USERNAME', 'hephyci+jenkins', 'Quay account name')
+    stringParam('QUAY_EMAIL', 'team+jenkins@teamhephy.com', 'Quay email address')
     stringParam('COMPONENT_NAME', '', 'Component name')
     stringParam('COMPONENT_SHA', '', 'Commit sha used for image tag')
     stringParam('UPSTREAM_SLACK_CHANNEL', defaults.slack.channel, "Upstream Slack channel")

--- a/jobs/component_promote.groovy
+++ b/jobs/component_promote.groovy
@@ -4,7 +4,7 @@ evaluate(new File("${workspace}/common.groovy"))
 
 job('component-promote') {
   description """
-    Promotes a component image to the production 'kingdonb' registry org on e2e success after a merge to master
+    Promotes a component image to the production 'hephyci' registry org on e2e success after a merge to master
   """.stripIndent().trim()
 
 

--- a/jobs/component_release.groovy
+++ b/jobs/component_release.groovy
@@ -13,7 +13,7 @@ repos.each { Map repo ->
           <li>Unless TAG is set (manual trigger), this job only runs off the latest tag.</li>
           <li>The commit at HEAD of tag is then used to locate the release candidate image(s).</li>
           <li>Kicks off downstream e2e job to vet candidate image(s).</li>
-          <li>Provided e2e tests pass, retags release candidate(s) with official semver tag in the 'kingdonb' registry orgs.</li>
+          <li>Provided e2e tests pass, retags release candidate(s) with official semver tag in the 'hephyci' registry orgs.</li>
         </ol>
       """.stripIndent().trim()
 
@@ -101,7 +101,7 @@ repos.each { Map repo ->
         shell main
 
         // Downstream jobs/pipeline START
-        // Trigger job to promote candidate image to 'prod' (kingdonb) image registries
+        // Trigger job to promote candidate image to 'prod' (hephyci) image registries
         conditionalSteps {
           condition { status('SUCCESS', 'SUCCESS') }
           steps {

--- a/jobs/component_release.groovy
+++ b/jobs/component_release.groovy
@@ -13,14 +13,14 @@ repos.each { Map repo ->
           <li>Unless TAG is set (manual trigger), this job only runs off the latest tag.</li>
           <li>The commit at HEAD of tag is then used to locate the release candidate image(s).</li>
           <li>Kicks off downstream e2e job to vet candidate image(s).</li>
-          <li>Provided e2e tests pass, retags release candidate(s) with official semver tag in the 'deis' registry orgs.</li>
+          <li>Provided e2e tests pass, retags release candidate(s) with official semver tag in the 'kingdonb' registry orgs.</li>
         </ol>
       """.stripIndent().trim()
 
       scm {
         git {
           remote {
-            github("deis/${repo.name}")
+            github("teamhephy/${repo.name}")
             credentials(defaults.github.credentialsID)
             refspec('+refs/tags/*:refs/remotes/origin/tags/*')
           }
@@ -101,7 +101,7 @@ repos.each { Map repo ->
         shell main
 
         // Downstream jobs/pipeline START
-        // Trigger job to promote candidate image to 'prod' (deis) image registries
+        // Trigger job to promote candidate image to 'prod' (kingdonb) image registries
         conditionalSteps {
           condition { status('SUCCESS', 'SUCCESS') }
           steps {

--- a/jobs/component_release_publish.groovy
+++ b/jobs/component_release_publish.groovy
@@ -10,7 +10,7 @@ job('component-release-publish') {
   scm {
     git {
       remote {
-        github("deis/workflow-manager-api-publish")
+        github("teamhephy/workflow-manager-api-publish")
         credentials(defaults.github.credentialsID)
       }
       branch('master')

--- a/jobs/deis_com.groovy
+++ b/jobs/deis_com.groovy
@@ -108,7 +108,7 @@ job("teamhephy-com-pr") {
   }
 
   triggers {
-    pullRequest {
+    githubPullRequest {
       admin('teamhephy-admin')
       cron('H/5 * * * *')
       useGitHubHooks()

--- a/jobs/deis_com.groovy
+++ b/jobs/deis_com.groovy
@@ -2,14 +2,14 @@ def workspace = new File(".").getAbsolutePath()
 if (!new File("${workspace}/common.groovy").canRead()) { workspace = "${WORKSPACE}"}
 evaluate(new File("${workspace}/common.groovy"))
 
-repo_name = 'deis.com'
-downstreamJobName = 'deis-com-deploy'
-slackChannel = '#marketing'
+repo_name = 'teamhephy.com'
+downstreamJobName = 'teamhephy-com-deploy'
+slackChannel = '#ci'
 
-job("deis-com-master") {
+job("teamhephy-com-master") {
   description """
     <ol>
-      <li>Watches the <a href="https://github.com/deisthree/${repo_name}">${repo_name}</a> repo for a commit to master</li>
+      <li>Watches the <a href="https://github.com/teamhephy/${repo_name}">${repo_name}</a> repo for a commit to master</li>
       <li>Kicks off downstream ${downstreamJobName} job to deploy docs</li>
     </ol>
   """.stripIndent().trim()
@@ -17,7 +17,7 @@ job("deis-com-master") {
   scm {
     git {
       remote {
-        github("deis/deis.com")
+        github("teamhephy/teamhephy.com")
         credentials(defaults.github.credentialsID)
       }
       branch('${DEIS_COM_BRANCH}')
@@ -64,7 +64,7 @@ job("deis-com-master") {
       string("SLACK_INCOMING_WEBHOOK_URL", defaults.slack.webhookURL)
     }
     parameters {
-      stringParam('DEIS_COM_BRANCH', 'master', 'deis.com branch to build')
+      stringParam('DEIS_COM_BRANCH', 'master', 'teamhephy.com branch to build')
     }
   }
 
@@ -79,7 +79,7 @@ job("deis-com-master") {
   }
 }
 
-job("deis-com-pr") {
+job("teamhephy-com-pr") {
   description """
     <ol>
       <li>Watches the ${repo_name} repo_name for pull requests</li>
@@ -89,7 +89,7 @@ job("deis-com-pr") {
   scm {
     git {
       remote {
-        github("deis/${repo_name}")
+        github("teamhephy/${repo_name}")
         credentials(defaults.github.credentialsID)
         refspec('+refs/pull/*:refs/remotes/origin/pr/*')
       }
@@ -109,11 +109,11 @@ job("deis-com-pr") {
 
   triggers {
     pullRequest {
-      admin('deis-admin')
+      admin('teamhephy-admin')
       cron('H/5 * * * *')
       useGitHubHooks()
       triggerPhrase('OK to test')
-      orgWhitelist(['deis'])
+      orgWhitelist(['teamhephy'])
       allowMembersOfWhitelistedOrgsAsAdmin()
       // this plugin will update PR status no matter what,
       // so until we fix this, here are our default messages:

--- a/jobs/deis_com_deploy.groovy
+++ b/jobs/deis_com_deploy.groovy
@@ -2,20 +2,20 @@ def workspace = new File(".").getAbsolutePath()
 if (!new File("${workspace}/common.groovy").canRead()) { workspace = "${WORKSPACE}"}
 evaluate(new File("${workspace}/common.groovy"))
 
-name = 'deis-com-deploy'
+name = 'teamhephy-com-deploy'
 slackChannel = '#marketing'
 
 job(name) {
   description """
     <ol>
-      <li>Compiles and deploys <a href="https://deis.com">deis.com</a></li>
+      <li>Compiles and deploys <a href="https://teamhephy.com">teamhephy.com</a></li>
     </ol>
   """.stripIndent().trim()
 
   multiscm {
    git {
      remote {
-         github('deis/gutenberg')
+         github('teamhephy/gutenberg')
          credentials(defaults.github.credentialsID)
      }
      extensions {
@@ -25,7 +25,7 @@ job(name) {
    }
    git {
      remote {
-         github('deis/workflow')
+         github('teamhephy/workflow')
          credentials(defaults.github.credentialsID)
      }
      extensions {
@@ -36,11 +36,11 @@ job(name) {
    }
    git {
      remote {
-         github('deis/deis.com')
+         github('teamhephy/teamhephy.com')
          credentials(defaults.github.credentialsID)
      }
      extensions {
-         relativeTargetDirectory('deis.com')
+         relativeTargetDirectory('teamhephy.com')
      }
      branch('master')
    }
@@ -85,9 +85,9 @@ job(name) {
     }
     parameters {
       stringParam('WORKFLOW_DOCS_SOURCE', '${WORKSPACE}/workflow', 'Relative Workflow source')
-      stringParam('DEIS_COM_SOURCE', '${WORKSPACE}/deis.com', 'Relative Deis.com source')
-      stringParam('QUAY_USERNAME', 'deis+jenkins', 'Quay account name')
-      stringParam('QUAY_EMAIL', 'deis+jenkins@deis.com', 'Quay email address')
+      stringParam('DEIS_COM_SOURCE', '${WORKSPACE}/teamhephy.com', 'Relative Teamhephy.com source')
+      stringParam('QUAY_USERNAME', 'teamhephy+jenkins', 'Quay account name')
+      stringParam('QUAY_EMAIL', 'team+jenkins@teamhephy.com', 'Quay email address')
     }
   }
 
@@ -104,7 +104,7 @@ job(name) {
       docker login -e="\$QUAY_EMAIL" -u="\$QUAY_USERNAME" -p="\$QUAY_PASSWORD" quay.io
       make prep build build-image push
 
-      curl -sSL http://deis.io/deis-cli/install-v2.sh | bash
+      curl -sSL http://teamhephy.info/hephy-cli/install-v2.sh | bash
       export PATH="\$(pwd):\$PATH"
 
       make deploy

--- a/jobs/deis_io.groovy
+++ b/jobs/deis_io.groovy
@@ -2,14 +2,14 @@ def workspace = new File(".").getAbsolutePath()
 if (!new File("${workspace}/common.groovy").canRead()) { workspace = "${WORKSPACE}"}
 evaluate(new File("${workspace}/common.groovy"))
 
-repo_name = 'deis.io'
-downstreamJobName = 'deis-io-deploy'
-slackChannel = '#marketing'
+repo_name = 'teamhephy.info'
+downstreamJobName = 'teamhephy-info-deploy'
+slackChannel = '#ci'
 
-job("deis-io-merge") {
+job("teamhephy-info-merge") {
   description """
     <ol>
-      <li>Watches the <a href="https://github.com/deisthree/${repo_name}">${repo_name}</a> repo for a commit to gh-pages</li>
+      <li>Watches the <a href="https://github.com/teamhephy/${repo_name}">${repo_name}</a> repo for a commit to gh-pages</li>
       <li>Kicks off downstream ${downstreamJobName} job to deploy</li>
     </ol>
   """.stripIndent().trim()
@@ -17,7 +17,7 @@ job("deis-io-merge") {
   scm {
     git {
       remote {
-        github("deis/${repo_name}")
+        github("teamhephy/${repo_name}")
         credentials(defaults.github.credentialsID)
       }
       branch('gh-pages')
@@ -80,7 +80,7 @@ job("deis-io-merge") {
   }
 }
 
-job("deis-io-pr") {
+job("teamhephy-info-pr") {
   description """
     <ol>
       <li>Watches the ${repo_name} repo_name for pull requests</li>
@@ -90,7 +90,7 @@ job("deis-io-pr") {
   scm {
     git {
       remote {
-        github("deis/${repo_name}")
+        github("teamhephy/${repo_name}")
         credentials(defaults.github.credentialsID)
         refspec('+refs/pull/*:refs/remotes/origin/pr/*')
       }
@@ -110,11 +110,11 @@ job("deis-io-pr") {
 
   triggers {
     pullRequest {
-      admin('deis-admin')
+      admin('teamhephy-admin')
       cron('H/5 * * * *')
       useGitHubHooks()
       triggerPhrase('OK to test')
-      orgWhitelist(['deis'])
+      orgWhitelist(['teamhephy'])
       allowMembersOfWhitelistedOrgsAsAdmin()
       // this plugin will update PR status no matter what,
       // so until we fix this, here are our default messages:
@@ -132,7 +132,7 @@ job("deis-io-pr") {
   }
 
   parameters {
-    stringParam('DEIS_IO_BRANCH', 'gh-pages', 'deis.io branch to build')
+    stringParam('DEIS_IO_BRANCH', 'gh-pages', 'teamhephy.info branch to build')
     stringParam('CONTAINER_ENV', '${DEIS_IO_STAGING_ENV}', 'Environment file with AWS API Keys, S3 Buckets and CloudFront values')
     stringParam('sha1', '${DEIS_IO_BRANCH}', 'Specific Git SHA to test')
   }

--- a/jobs/deis_io.groovy
+++ b/jobs/deis_io.groovy
@@ -109,7 +109,7 @@ job("teamhephy-info-pr") {
   }
 
   triggers {
-    pullRequest {
+    githubPullRequest {
       admin('teamhephy-admin')
       cron('H/5 * * * *')
       useGitHubHooks()

--- a/jobs/deis_io_deploy.groovy
+++ b/jobs/deis_io_deploy.groovy
@@ -2,20 +2,20 @@ def workspace = new File(".").getAbsolutePath()
 if (!new File("${workspace}/common.groovy").canRead()) { workspace = "${WORKSPACE}"}
 evaluate(new File("${workspace}/common.groovy"))
 
-name = 'deis-io-deploy'
+name = 'teamhephy-info-deploy'
 slackChannel = '#marketing'
 
 job(name) {
   description """
     <ol>
-      <li>Compiles and deploys <a href="https://deis.io">deis.io</a></li>
+      <li>Compiles and deploys <a href="https://teamhephy.info">teamhephy.info</a></li>
     </ol>
   """.stripIndent().trim()
 
   scm {
     git {
       remote {
-        github('${DEIS_IO_ORG}/deis.io')
+        github('${DEIS_IO_ORG}/teamhephy.info')
           credentials(defaults.github.credentialsID)
       }
       branch('${DEIS_IO_BRANCH}')
@@ -59,10 +59,10 @@ job(name) {
       string("DEIS_PASSWORD", "201494de-a097-4a60-aaa3-6d16a930dabd")
     }
     parameters {
-      stringParam('QUAY_USERNAME', 'deis+jenkins', 'Quay account name')
-      stringParam('QUAY_EMAIL', 'deis+jenkins@deis.com', 'Quay email address')
-      stringParam('DEIS_IO_ORG', 'deis', 'GitHub organization to use.')
-      stringParam('DEIS_IO_BRANCH', 'gh-pages', 'deis.io branch to deploy')
+      stringParam('QUAY_USERNAME', 'teamhephy+jenkins', 'Quay account name')
+      stringParam('QUAY_EMAIL', 'team+jenkins@teamhephy.com', 'Quay email address')
+      stringParam('DEIS_IO_ORG', 'teamhephy', 'GitHub organization to use.')
+      stringParam('DEIS_IO_BRANCH', 'gh-pages', 'teamhephy.info branch to deploy')
     }
   }
 
@@ -75,7 +75,7 @@ job(name) {
       docker login -e="\$QUAY_EMAIL" -u="\$QUAY_USERNAME" -p="\$QUAY_PASSWORD" quay.io
       make prep build build-image push
 
-      curl -sSL http://deis.io/deis-cli/install-v2.sh | bash
+      curl -sSL http://teamhephy.info/hephy-cli/install-v2.sh | bash
       export PATH="\$(pwd):\$PATH"
 
       make deploy

--- a/jobs/helm_chart_verify.groovy
+++ b/jobs/helm_chart_verify.groovy
@@ -3,7 +3,7 @@ if (!new File("${workspace}/common.groovy").canRead()) { workspace = "${WORKSPAC
 evaluate(new File("${workspace}/common.groovy"))
 
 job("helm-chart-verify") {
-  description "Verifies a signed Deis Helm chart"
+  description "Verifies a signed Hephy Helm chart"
 
   publishers {
     postBuildScripts {
@@ -65,7 +65,7 @@ job("helm-chart-verify") {
         mkdir -p "${HOME}/.gnupg"
         touch "${HOME}/.gnupg/pubring.gpg"
 
-        helm repo add "${CHART}" https://charts.deis.com/"${CHART_REPO}"
+        helm repo add "${CHART}" https://charts.teamhephy.com/"${CHART_REPO}"
         helm fetch --verify "${CHART_REPO}"/"${CHART}" --version "${RELEASE_TAG}"
       '''.stripIndent().trim()
   }

--- a/jobs/helm_www.groovy
+++ b/jobs/helm_www.groovy
@@ -105,7 +105,7 @@ job("helm-www-pr") {
   }
 
   triggers {
-    pullRequest {
+    githubPullRequest {
       admin('teamhephy-admin')
       cron('H/5 * * * *')
       useGitHubHooks()

--- a/jobs/helm_www.groovy
+++ b/jobs/helm_www.groovy
@@ -106,11 +106,11 @@ job("helm-www-pr") {
 
   triggers {
     pullRequest {
-      admin('deis-admin')
+      admin('teamhephy-admin')
       cron('H/5 * * * *')
       useGitHubHooks()
       triggerPhrase('OK to test')
-      orgWhitelist(['deis'])
+      orgWhitelist(['teamhephy'])
       allowMembersOfWhitelistedOrgsAsAdmin()
       // this plugin will update PR status no matter what,
       // so until we fix this, here are our default messages:

--- a/jobs/helm_www_deploy.groovy
+++ b/jobs/helm_www_deploy.groovy
@@ -49,8 +49,8 @@ job(name) {
   }
 
   parameters {
-    stringParam('QUAY_USERNAME', 'deis+jenkins', 'Quay account name')
-    stringParam('QUAY_EMAIL', 'deis+jenkins@deis.com', 'Quay email address')
+    stringParam('QUAY_USERNAME', 'teamhephy+jenkins', 'Quay account name')
+    stringParam('QUAY_EMAIL', 'team+jenkins@teamhephy.com', 'Quay email address')
   }
 
   wrappers {
@@ -75,7 +75,7 @@ job(name) {
       docker login -e="\$QUAY_EMAIL" -u="\$QUAY_USERNAME" -p="\$QUAY_PASSWORD" quay.io
       make build build-image push
 
-      curl -sSL http://deis.io/deis-cli/install-v2.sh | bash
+      curl -sSL http://teamhephy.info/hephy-cli/install-v2.sh | bash
       export PATH="\$(pwd):\$PATH"
 
       make deploy

--- a/jobs/helm_www_docs.groovy
+++ b/jobs/helm_www_docs.groovy
@@ -106,7 +106,7 @@ job("helm-www-docs-pr") {
   }
 
   triggers {
-    pullRequest {
+    githubPullRequest {
       admin('teamhephy-admin')
       cron('H/5 * * * *')
       useGitHubHooks()

--- a/jobs/helm_www_docs.groovy
+++ b/jobs/helm_www_docs.groovy
@@ -107,11 +107,11 @@ job("helm-www-docs-pr") {
 
   triggers {
     pullRequest {
-      admin('deis-admin')
+      admin('teamhephy-admin')
       cron('H/5 * * * *')
       useGitHubHooks()
       triggerPhrase('OK to test')
-      orgWhitelist(['deis'])
+      orgWhitelist(['teamhephy'])
       allowMembersOfWhitelistedOrgsAsAdmin()
       // this plugin will update PR status no matter what,
       // so until we fix this, here are our default messages:

--- a/jobs/helm_www_docs_deploy.groovy
+++ b/jobs/helm_www_docs_deploy.groovy
@@ -60,8 +60,8 @@ job(name) {
       string("DEIS_PASSWORD", "201494de-a097-4a60-aaa3-6d16a930dabd")
     }
     parameters {
-      stringParam('QUAY_USERNAME', 'deis+jenkins', 'Quay account name')
-      stringParam('QUAY_EMAIL', 'deis+jenkins@deis.com', 'Quay email address')
+      stringParam('QUAY_USERNAME', 'teamhephy+jenkins', 'Quay account name')
+      stringParam('QUAY_EMAIL', 'team+jenkins@teamhephy.com', 'Quay email address')
     }
   }
 
@@ -76,7 +76,7 @@ job(name) {
       docker login -e="\$QUAY_EMAIL" -u="\$QUAY_USERNAME" -p="\$QUAY_PASSWORD" quay.io
       make prep build build-image push
 
-      curl -sSL http://deis.io/deis-cli/install-v2.sh | bash
+      curl -sSL http://teamhephy.info/hephy-cli/install-v2.sh | bash
       export PATH="\$(pwd):\$PATH"
 
       make deploy

--- a/jobs/jenkins_jobs_pr.groovy
+++ b/jobs/jenkins_jobs_pr.groovy
@@ -7,7 +7,7 @@ name = 'jenkins-jobs-pr'
 job(name) {
   description """
     <ol>
-      <li>Watches the <a href="https://github.com/deisthree/jenkins-jobs">jenkins-jobs</a> repo for a PR commit</li>
+      <li>Watches the <a href="https://github.com/teamhephy/jenkins-jobs">jenkins-jobs</a> repo for a PR commit</li>
       <li>and runs tests against changes</li>
     </ol>
   """.stripIndent().trim()
@@ -15,7 +15,7 @@ job(name) {
   scm {
     git {
       remote {
-        github("deis/jenkins-jobs")
+        github("teamhephy/jenkins-jobs")
         credentials(defaults.github.credentialsID)
         refspec('+refs/pull/*:refs/remotes/origin/pr/*')
       }
@@ -41,11 +41,11 @@ job(name) {
     githubPush()
 
     pullRequest {
-      admin('deis-admin')
+      admin('teamhephy-admin')
       cron('H/5 * * * *')
       useGitHubHooks()
       triggerPhrase('OK to test')
-      orgWhitelist(['deis'])
+      orgWhitelist(['teamhephy'])
       allowMembersOfWhitelistedOrgsAsAdmin()
       extensions {
         commitStatus {

--- a/jobs/jenkins_jobs_pr.groovy
+++ b/jobs/jenkins_jobs_pr.groovy
@@ -40,7 +40,7 @@ job(name) {
   triggers {
     githubPush()
 
-    pullRequest {
+    githubPullRequest {
       admin('teamhephy-admin')
       cron('H/5 * * * *')
       useGitHubHooks()

--- a/jobs/k8s_claimer.groovy
+++ b/jobs/k8s_claimer.groovy
@@ -56,7 +56,7 @@ job('k8s-claimer-pr') {
   }
 
   triggers {
-    pullRequest {
+    githubPullRequest {
       admin('teamhephy-admin')
       cron('H/5 * * * *')
       useGitHubHooks()

--- a/jobs/k8s_claimer.groovy
+++ b/jobs/k8s_claimer.groovy
@@ -15,7 +15,7 @@ job('k8s-claimer-pr') {
   scm {
     git {
       remote {
-        github("deis/k8s-claimer")
+        github("teamhephy/k8s-claimer")
         credentials(defaults.github.credentialsID)
         refspec('+refs/pull/*:refs/remotes/origin/pr/*')
       }
@@ -57,11 +57,11 @@ job('k8s-claimer-pr') {
 
   triggers {
     pullRequest {
-      admin('deis-admin')
+      admin('teamhephy-admin')
       cron('H/5 * * * *')
       useGitHubHooks()
       triggerPhrase('OK to test')
-      orgWhitelist(['deis'])
+      orgWhitelist(['teamhephy'])
       allowMembersOfWhitelistedOrgsAsAdmin()
       // this plugin will update PR status no matter what,
       // so until we fix this, here are our default messages:
@@ -121,7 +121,7 @@ job('k8s-claimer-build-cli') {
   scm {
     git {
       remote {
-        github('deis/k8s-claimer')
+        github('teamhephy/k8s-claimer')
         credentials(defaults.github.credentialsID)
       }
       branch('master')
@@ -188,8 +188,8 @@ job('k8s-claimer-build-cli') {
 
 job('k8s-claimer-deploy') {
   description """
-  <p>Compiles and deploys <a href="https://github.com/deisthree/k8s-claimer">k8s-claimer</a>
-    to the Deis Workflow staging cluster.
+  <p>Compiles and deploys <a href="https://github.com/teamhephy/k8s-claimer">k8s-claimer</a>
+    to the Hephy Workflow staging cluster.
   </p>
   <p>
     K8s-Claimer serves as a Kubernetes cluster leaser for running Workflow E2E tests in CI.
@@ -199,7 +199,7 @@ job('k8s-claimer-deploy') {
   scm {
     git {
       remote {
-        github('deis/k8s-claimer')
+        github('teamhephy/k8s-claimer')
         credentials(defaults.github.credentialsID)
       }
       branch('master')
@@ -233,8 +233,8 @@ job('k8s-claimer-deploy') {
   }
 
   parameters {
-    stringParam('QUAY_USERNAME', 'deis+jenkins', 'Quay account name')
-    stringParam('QUAY_EMAIL', 'deis+jenkins@deis.com', 'Quay email address')
+    stringParam('QUAY_USERNAME', 'teamhephy+jenkins', 'Quay account name')
+    stringParam('QUAY_EMAIL', 'team+jenkins@teamhephy.com', 'Quay email address')
   }
 
   wrappers {
@@ -267,7 +267,7 @@ job('k8s-claimer-deploy') {
       export DEV_REGISTRY=quay.io/
       docker login -e="\$QUAY_EMAIL" -u="\$QUAY_USERNAME" -p="\$QUAY_PASSWORD" quay.io
 
-      DOCKER_BUILD_FLAGS="--pull --no-cache" KUBECONFIG=kubeconfig ARGS=config.ssh_key=\${K8S_CLAIMER_SSH_KEY},config.google.account_file=\${GOOGLE_CLOUD_ACCOUNT_FILE},config.google.project_id=deis-e2e-leasable,config.auth_token=\${AUTH_TOKEN},config.namespace=k8sclaimer,config.azure.subscription_id=\${AZURE_SUBSCRIPTION_ID},config.azure.client_id=\${AZURE_CLIENT_ID},config.azure.client_secret=\${AZURE_CLIENT_SECRET},config.azure.tenant_id=\${AZURE_TENANT_ID} make bootstrap build push upgrade
+      DOCKER_BUILD_FLAGS="--pull --no-cache" KUBECONFIG=kubeconfig ARGS=config.ssh_key=\${K8S_CLAIMER_SSH_KEY},config.google.account_file=\${GOOGLE_CLOUD_ACCOUNT_FILE},config.google.project_id=teamhephy-e2e-leasable,config.auth_token=\${AUTH_TOKEN},config.namespace=k8sclaimer,config.azure.subscription_id=\${AZURE_SUBSCRIPTION_ID},config.azure.client_id=\${AZURE_CLIENT_ID},config.azure.client_secret=\${AZURE_CLIENT_SECRET},config.azure.tenant_id=\${AZURE_TENANT_ID} make bootstrap build push upgrade
       """.stripIndent().trim()
   }
 }

--- a/jobs/k8s_claimer.groovy
+++ b/jobs/k8s_claimer.groovy
@@ -159,8 +159,8 @@ job('k8s-claimer-build-cli') {
     timestamps()
     colorizeOutput 'xterm'
     credentialsBinding {
-      string("AZURE_STORAGE_ACCOUNT", "bd50d9e8-feed-4f37-9833-10728d0d1840")
-      string("AZURE_STORAGE_KEY", "0211420f-1544-4543-b7bf-0c21dddf5db1")
+      string("AZURE_STORAGE_ACCOUNT", defaults.azure.storageAccount)
+      string("AZURE_STORAGE_KEY", defaults.azure.storageAccountKeyID)
       string("GITHUB_ACCESS_TOKEN", defaults.github.accessTokenCredentialsID)
       string("SLACK_INCOMING_WEBHOOK_URL", defaults.slack.webhookURL)
     }

--- a/jobs/k8s_claimer.groovy
+++ b/jobs/k8s_claimer.groovy
@@ -92,7 +92,7 @@ job('k8s-claimer-pr') {
     credentialsBinding {
       string("GITHUB_ACCESS_TOKEN", defaults.github.accessTokenCredentialsID)
       string("SLACK_INCOMING_WEBHOOK_URL", defaults.slack.webhookURL)
-      string("CODECOV_TOKEN", "a31b1ad5-523a-41f8-b844-6240a349c4d0")
+      string("CODECOV_TOKEN", "38103128-b4b3-4ed9-ac6b-231ef93f0671")
     }
   }
 

--- a/jobs/release_candidate_promote.groovy
+++ b/jobs/release_candidate_promote.groovy
@@ -34,10 +34,10 @@ job('release-candidate-promote') {
   }
 
   parameters {
-    stringParam('DOCKER_USERNAME', 'hephybot', 'Docker Hub account name')
-    stringParam('DOCKER_EMAIL', 'dummy-address@teamhephy.com', 'Docker Hub email address')
-    stringParam('QUAY_USERNAME', 'teamhephy+jenkins', 'Quay account name')
-    stringParam('QUAY_EMAIL', 'team+jenkins@teamhephy.com', 'Quay email address')
+    stringParam('DOCKER_USERNAME', 'hephyci', 'Docker Hub account name')
+    stringParam('DOCKER_EMAIL', 'kingdon@teamhephy.com', 'Docker Hub email address')
+    stringParam('QUAY_USERNAME', 'hephyci', 'Quay account name')
+    stringParam('QUAY_EMAIL', 'team@teamhephy.com', 'Quay email address')
     stringParam('COMPONENT_NAME', '', 'Component name')
     stringParam('COMPONENT_SHA', '', 'Commit sha used for candidate image tag')
     stringParam('RELEASE_TAG', '', 'Release tag value for retagging candidate image')
@@ -49,8 +49,8 @@ job('release-candidate-promote') {
     timestamps()
     colorizeOutput 'xterm'
     credentialsBinding {
-      string("DOCKER_PASSWORD", "0d1f268f-407d-4cd9-a3c2-0f9671df0104")
-      string("QUAY_PASSWORD", "8317a529-10f7-40b5-abd4-a42f242f22f0")
+      string("DOCKER_PASSWORD", "171dca49-defe-44a9-8d31-b66f69509133")
+      string("QUAY_PASSWORD", "40ea7a06-8e1d-4d09-81be-45f0ce07ce27")
       string("SLACK_INCOMING_WEBHOOK_URL", defaults.slack.webhookURL)
     }
   }

--- a/jobs/release_candidate_promote.groovy
+++ b/jobs/release_candidate_promote.groovy
@@ -4,7 +4,7 @@ evaluate(new File("${workspace}/common.groovy"))
 
 job('release-candidate-promote') {
   description """
-    Promotes a release candidate image by retagging with the official semver tag to the production 'deis' registry org on an upstream e2e success
+    Promotes a release candidate image by retagging with the official semver tag to the production 'kingdonb' registry org on an upstream e2e success
   """.stripIndent().trim()
 
 
@@ -34,10 +34,10 @@ job('release-candidate-promote') {
   }
 
   parameters {
-    stringParam('DOCKER_USERNAME', 'deisbot', 'Docker Hub account name')
-    stringParam('DOCKER_EMAIL', 'dummy-address@deis.com', 'Docker Hub email address')
-    stringParam('QUAY_USERNAME', 'deis+jenkins', 'Quay account name')
-    stringParam('QUAY_EMAIL', 'deis+jenkins@deis.com', 'Quay email address')
+    stringParam('DOCKER_USERNAME', 'hephybot', 'Docker Hub account name')
+    stringParam('DOCKER_EMAIL', 'dummy-address@teamhephy.com', 'Docker Hub email address')
+    stringParam('QUAY_USERNAME', 'teamhephy+jenkins', 'Quay account name')
+    stringParam('QUAY_EMAIL', 'team+jenkins@teamhephy.com', 'Quay email address')
     stringParam('COMPONENT_NAME', '', 'Component name')
     stringParam('COMPONENT_SHA', '', 'Commit sha used for candidate image tag')
     stringParam('RELEASE_TAG', '', 'Release tag value for retagging candidate image')

--- a/jobs/release_candidate_promote.groovy
+++ b/jobs/release_candidate_promote.groovy
@@ -4,7 +4,7 @@ evaluate(new File("${workspace}/common.groovy"))
 
 job('release-candidate-promote') {
   description """
-    Promotes a release candidate image by retagging with the official semver tag to the production 'kingdonb' registry org on an upstream e2e success
+    Promotes a release candidate image by retagging with the official semver tag to the production 'hephyci' registry org on an upstream e2e success
   """.stripIndent().trim()
 
 

--- a/jobs/seed_repos.groovy
+++ b/jobs/seed_repos.groovy
@@ -2,18 +2,18 @@ def workspace = new File(".").getAbsolutePath()
 if (!new File("${workspace}/common.groovy").canRead()) { workspace = "${WORKSPACE}"}
 evaluate(new File("${workspace}/common.groovy"))
 
-name = 'deis-seed-repos'
+name = 'teamhephy-seed-repos'
 repoName = 'seed-repo'
 
 job(name) {
   description """
-    <p>Runs deis/seed-repo against all of the workflow components.</p>
+    <p>Runs teamhephy/seed-repo against all of the workflow components.</p>
   """.stripIndent().trim()
 
   scm {
     git {
       remote {
-        github("deis/${repoName}")
+        github("teamhephy/${repoName}")
       }
       branch('master')
     }

--- a/jobs/storage_test.groovy
+++ b/jobs/storage_test.groovy
@@ -12,13 +12,13 @@ def bucketNames = [
 
 job(name) {
   description """
-    <p>Nightly Job runs the <a href="https://github.com/deisthree/workflow-e2e">e2e tests</a> against a <a href="https://github.com/deisthree/charts/tree/master/workflow-dev">workflow-dev</a> chart configured to GCS by default </p>
+    <p>Nightly Job runs the <a href="https://github.com/teamhephy/workflow-e2e">e2e tests</a> against a <a href="https://github.com/teamhephy/charts/tree/master/workflow-dev">workflow-dev</a> chart configured to GCS by default </p>
   """.stripIndent().trim()
 
   scm {
     git {
       remote {
-        github("deis/e2e-runner")
+        github("teamhephy/e2e-runner")
       }
       branch('master')
     }
@@ -31,7 +31,7 @@ job(name) {
   parameters {
    choiceParam('STORAGE_TYPE', ['gcs', 's3'], "storage backend for helm chart, default is gcs")
    stringParam('HELM_VERSION', defaults.helm.version, 'Version of Helm to download/use')
-   stringParam('E2E_RUNNER_IMAGE', 'quay.io/deisci/e2e-runner:canary', "The e2e-runner image")
+   stringParam('E2E_RUNNER_IMAGE', 'quay.io/kingdonb/e2e-runner:canary', "The e2e-runner image")
    stringParam('E2E_DIR', '/home/jenkins/workspace/$JOB_NAME/$BUILD_NUMBER', "Directory for storing workspace files")
    stringParam('E2E_DIR_LOGS', '${E2E_DIR}/logs', "Directory for storing logs. This directory is mounted into the e2e-runner container")
    stringParam('WORKFLOW_TAG', '', 'Workflow chart version (default: empty, will pull latest from chart repo)')

--- a/jobs/storage_test.groovy
+++ b/jobs/storage_test.groovy
@@ -31,7 +31,7 @@ job(name) {
   parameters {
    choiceParam('STORAGE_TYPE', ['gcs', 's3'], "storage backend for helm chart, default is gcs")
    stringParam('HELM_VERSION', defaults.helm.version, 'Version of Helm to download/use')
-   stringParam('E2E_RUNNER_IMAGE', 'quay.io/kingdonb/e2e-runner:canary', "The e2e-runner image")
+   stringParam('E2E_RUNNER_IMAGE', 'quay.io/hephyci/e2e-runner:canary', "The e2e-runner image")
    stringParam('E2E_DIR', '/home/jenkins/workspace/$JOB_NAME/$BUILD_NUMBER', "Directory for storing workspace files")
    stringParam('E2E_DIR_LOGS', '${E2E_DIR}/logs', "Directory for storing logs. This directory is mounted into the e2e-runner container")
    stringParam('WORKFLOW_TAG', '', 'Workflow chart version (default: empty, will pull latest from chart repo)')

--- a/jobs/workflow_chart_pipeline.groovy
+++ b/jobs/workflow_chart_pipeline.groovy
@@ -12,7 +12,7 @@ job("${chart}-chart-publish") {
   scm {
     git {
       remote {
-        github("deis/${repo.name}")
+        github("teamhephy/${repo.name}")
         credentials(defaults.github.credentialsID)
       }
       branch('master')
@@ -106,7 +106,7 @@ job("${chart}-chart-publish") {
         # checkout PR commit if repo_type 'pr' and value of commit env var non-null
         if [ "\${CHART_REPO_TYPE}" == 'pr' ] && [ -n "\${${repo.commitEnvVar}}" ]; then
           echo "Fetching PR changes from repo '${repo.name}' at commit \${${repo.commitEnvVar}}" 1>&2
-          git fetch -q --tags --progress https://github.com/deisthree/${repo.name}.git +refs/pull/*:refs/remotes/origin/pr/*
+          git fetch -q --tags --progress https://github.com/teamhephy/${repo.name}.git +refs/pull/*:refs/remotes/origin/pr/*
           git checkout "\${${repo.commitEnvVar}}"
         fi
 
@@ -210,7 +210,7 @@ job("${chart}-chart-e2e") {
     choiceParam('CHART_REPO_TYPE', ['dev', 'pr', 'staging', 'production'], 'Type of chart repo for publishing (default: dev)')
     stringParam('HELM_VERSION', defaults.helm.version, 'Version of Helm to download/use')
     stringParam('GINKGO_NODES', '15', "Number of parallel executors to use when running e2e tests")
-    stringParam('E2E_RUNNER_IMAGE', 'quay.io/deisci/e2e-runner:canary', "The e2e-runner image")
+    stringParam('E2E_RUNNER_IMAGE', 'quay.io/kingdonb/e2e-runner:canary', "The e2e-runner image")
     stringParam('E2E_DIR', '/home/jenkins/workspace/$JOB_NAME/$BUILD_NUMBER', "Directory for storing workspace files")
     stringParam('E2E_DIR_LOGS', '${E2E_DIR}/logs', "Directory for storing logs. This directory is mounted into the e2e-runner container")
     stringParam('CLUSTER_REGEX', '', 'K8s cluster regex (name) to supply when requesting cluster')
@@ -267,7 +267,7 @@ job("${chart}-chart-stage") {
   scm {
     git {
       remote {
-        github("deis/${repo.name}")
+        github("teamhephy/${repo.name}")
         credentials(defaults.github.credentialsID)
       }
       branch('master')
@@ -417,7 +417,7 @@ job("${chart}-chart-release") {
         az storage blob download -c ${chartRepo.production} -n index.yaml -f index.yaml
 
         # update index file
-        helm repo index . --url https://charts.deis.com/${chartRepo.production} --merge ./index.yaml
+        helm repo index . --url https://charts.teamhephy.com/${chartRepo.production} --merge ./index.yaml
 
         echo "Uploading updated index.yaml file to chart repo ${chartRepo.production}..."
         az storage blob upload -c ${chartRepo.production} -n index.yaml -f index.yaml

--- a/jobs/workflow_chart_pipeline.groovy
+++ b/jobs/workflow_chart_pipeline.groovy
@@ -322,7 +322,7 @@ job("${chart}-chart-stage") {
       string("AZURE_STORAGE_ACCOUNT", defaults.azure.storageAccount)
       string("AZURE_STORAGE_KEY", defaults.azure.storageAccountKeyID)
       string("SLACK_INCOMING_WEBHOOK_URL", defaults.slack.webhookURL)
-      string("SIGNING_KEY_PASSPHRASE", '3963b12b-bad3-429b-b1e5-e047a159bf02')
+      string("SIGNING_KEY_PASSPHRASE", '34783e47-b172-4227-877f-acbffb335ab7')
     }
   }
 

--- a/jobs/workflow_chart_pipeline.groovy
+++ b/jobs/workflow_chart_pipeline.groovy
@@ -210,7 +210,7 @@ job("${chart}-chart-e2e") {
     choiceParam('CHART_REPO_TYPE', ['dev', 'pr', 'staging', 'production'], 'Type of chart repo for publishing (default: dev)')
     stringParam('HELM_VERSION', defaults.helm.version, 'Version of Helm to download/use')
     stringParam('GINKGO_NODES', '15', "Number of parallel executors to use when running e2e tests")
-    stringParam('E2E_RUNNER_IMAGE', 'quay.io/kingdonb/e2e-runner:canary', "The e2e-runner image")
+    stringParam('E2E_RUNNER_IMAGE', 'quay.io/hephyci/e2e-runner:canary', "The e2e-runner image")
     stringParam('E2E_DIR', '/home/jenkins/workspace/$JOB_NAME/$BUILD_NUMBER', "Directory for storing workspace files")
     stringParam('E2E_DIR_LOGS', '${E2E_DIR}/logs', "Directory for storing logs. This directory is mounted into the e2e-runner container")
     stringParam('CLUSTER_REGEX', '', 'K8s cluster regex (name) to supply when requesting cluster')

--- a/jobs/workflow_cli_release.groovy
+++ b/jobs/workflow_cli_release.groovy
@@ -76,7 +76,7 @@ job("${repoName}-release") {
     timestamps()
     colorizeOutput 'xterm'
     credentialsBinding {
-      string("SLACK_INCOMING_WEBHOOK_URL", defaults.slack.webhookURL)
+      string("SLACK_INCOMING_WEBHOOK_URL", "SLACK_INCOMING_WEBHOOK_URL")
     }
   }
 
@@ -161,8 +161,8 @@ downstreamJobs.each{ Map thisJob ->
       timestamps()
       colorizeOutput 'xterm'
       credentialsBinding {
-        string("GCSKEY", "6561701c-b7b4-4796-83c4-9d87946799e4")
-        string("SLACK_INCOMING_WEBHOOK_URL", defaults.slack.webhookURL)
+        string("GCSKEY", "GCSKEY")
+        string("SLACK_INCOMING_WEBHOOK_URL", "SLACK_INCOMING_WEBHOOK_URL")
       }
     }
 
@@ -253,9 +253,9 @@ downstreamJobs.each{ Map thisJob ->
       timestamps()
       colorizeOutput 'xterm'
       credentialsBinding {
-        string("GITHUB_ACCESS_TOKEN", defaults.github.accessTokenCredentialsID)
-        string("GCSKEY", "6561701c-b7b4-4796-83c4-9d87946799e4")
-        string("SLACK_INCOMING_WEBHOOK_URL", defaults.slack.webhookURL)
+        string("GITHUB_ACCESS_TOKEN", "GITHUB_ACCESS_TOKEN")
+        string("GCSKEY", "GCSKEY")
+        string("SLACK_INCOMING_WEBHOOK_URL", "SLACK_INCOMING_WEBHOOK_URL")
       }
     }
 

--- a/jobs/workflow_cli_release.groovy
+++ b/jobs/workflow_cli_release.groovy
@@ -76,7 +76,7 @@ job("${repoName}-release") {
     timestamps()
     colorizeOutput 'xterm'
     credentialsBinding {
-      string("SLACK_INCOMING_WEBHOOK_URL", "SLACK_INCOMING_WEBHOOK_URL")
+      string("SLACK_INCOMING_WEBHOOK_URL", "95f29b21-3cd5-44b3-9a7b-c0b8bbf77b5d")
     }
   }
 
@@ -162,7 +162,7 @@ downstreamJobs.each{ Map thisJob ->
       colorizeOutput 'xterm'
       credentialsBinding {
         string("GCSKEY", "GCSKEY")
-        string("SLACK_INCOMING_WEBHOOK_URL", "SLACK_INCOMING_WEBHOOK_URL")
+        string("SLACK_INCOMING_WEBHOOK_URL", "95f29b21-3cd5-44b3-9a7b-c0b8bbf77b5d")
       }
     }
 
@@ -255,7 +255,7 @@ downstreamJobs.each{ Map thisJob ->
       credentialsBinding {
         string("GITHUB_ACCESS_TOKEN", "GITHUB_ACCESS_TOKEN")
         string("GCSKEY", "GCSKEY")
-        string("SLACK_INCOMING_WEBHOOK_URL", "SLACK_INCOMING_WEBHOOK_URL")
+        string("SLACK_INCOMING_WEBHOOK_URL", "95f29b21-3cd5-44b3-9a7b-c0b8bbf77b5d")
       }
     }
 

--- a/jobs/workflow_cli_release.groovy
+++ b/jobs/workflow_cli_release.groovy
@@ -106,7 +106,7 @@ job("${repoName}-release") {
 }
 
 downstreamJobs.each{ Map thisJob ->
-  def bucket = "gs://workflow-cli-release"
+  def bucket = "gs://hephy-cli-release"
 
   def headers  = "-h 'x-goog-meta-ci-job:\${JOB_NAME}' "
       headers += "-h 'x-goog-meta-ci-number:\${BUILD_NUMBER}' "
@@ -173,7 +173,7 @@ downstreamJobs.each{ Map thisJob ->
         set -eo pipefail
 
         git_commit="\$(git checkout "\${TAG}" && git rev-parse HEAD)"
-        revision_image=quay.io/kingdonb/workflow-cli-dev:"\${git_commit:0:7}"
+        revision_image=quay.io/deisci/workflow-cli-dev:"\${git_commit:0:7}"
 
         docker run \
           -e GCS_KEY_JSON=\""\${GCSKEY}"\" \
@@ -269,7 +269,7 @@ downstreamJobs.each{ Map thisJob ->
           cd ${workdir}
 
           git_commit="\$(git checkout "\${TAG}" && git rev-parse HEAD)"
-          revision_image=quay.io/kingdonb/workflow-cli-dev:"\${git_commit:0:7}"
+          revision_image=quay.io/deisci/workflow-cli-dev:"\${git_commit:0:7}"
 
           build-darwin-cli-binary ${thisJob.target}
 

--- a/jobs/workflow_cli_release.groovy
+++ b/jobs/workflow_cli_release.groovy
@@ -6,7 +6,7 @@ def repoName = 'workflow-cli'
 def repo = repos.find{ it.name == repoName }
 
 def gitInfo = [
-  repo: "kingdonb/${repoName}",
+  repo: "hephyci/${repoName}",
   creds: defaults.github.credentialsID,
   refspec: '+refs/tags/*:refs/remotes/origin/tags/*',
   branch: '*/tags/*',
@@ -173,7 +173,7 @@ downstreamJobs.each{ Map thisJob ->
         set -eo pipefail
 
         git_commit="\$(git checkout "\${TAG}" && git rev-parse HEAD)"
-        revision_image=quay.io/kingdonb/workflow-cli-dev:"\${git_commit:0:7}"
+        revision_image=quay.io/hephyci/workflow-cli-dev:"\${git_commit:0:7}"
 
         docker run \
           -e GCS_KEY_JSON=\""\${GCSKEY}"\" \
@@ -269,7 +269,7 @@ downstreamJobs.each{ Map thisJob ->
           cd ${workdir}
 
           git_commit="\$(git checkout "\${TAG}" && git rev-parse HEAD)"
-          revision_image=quay.io/kingdonb/workflow-cli-dev:"\${git_commit:0:7}"
+          revision_image=quay.io/hephyci/workflow-cli-dev:"\${git_commit:0:7}"
 
           build-darwin-cli-binary ${thisJob.target}
 

--- a/jobs/workflow_cli_release.groovy
+++ b/jobs/workflow_cli_release.groovy
@@ -6,7 +6,7 @@ def repoName = 'workflow-cli'
 def repo = repos.find{ it.name == repoName }
 
 def gitInfo = [
-  repo: "teamhephy/${repoName}",
+  repo: "kingdonb/${repoName}",
   creds: defaults.github.credentialsID,
   refspec: '+refs/tags/*:refs/remotes/origin/tags/*',
   branch: '*/tags/*',
@@ -173,7 +173,7 @@ downstreamJobs.each{ Map thisJob ->
         set -eo pipefail
 
         git_commit="\$(git checkout "\${TAG}" && git rev-parse HEAD)"
-        revision_image=quay.io/deisci/workflow-cli-dev:"\${git_commit:0:7}"
+        revision_image=quay.io/kingdonb/workflow-cli-dev:"\${git_commit:0:7}"
 
         docker run \
           -e GCS_KEY_JSON=\""\${GCSKEY}"\" \
@@ -269,7 +269,7 @@ downstreamJobs.each{ Map thisJob ->
           cd ${workdir}
 
           git_commit="\$(git checkout "\${TAG}" && git rev-parse HEAD)"
-          revision_image=quay.io/deisci/workflow-cli-dev:"\${git_commit:0:7}"
+          revision_image=quay.io/kingdonb/workflow-cli-dev:"\${git_commit:0:7}"
 
           build-darwin-cli-binary ${thisJob.target}
 

--- a/jobs/workflow_cli_release.groovy
+++ b/jobs/workflow_cli_release.groovy
@@ -6,7 +6,7 @@ def repoName = 'workflow-cli'
 def repo = repos.find{ it.name == repoName }
 
 def gitInfo = [
-  repo: "deis/${repoName}",
+  repo: "teamhephy/${repoName}",
   creds: defaults.github.credentialsID,
   refspec: '+refs/tags/*:refs/remotes/origin/tags/*',
   branch: '*/tags/*',
@@ -173,7 +173,7 @@ downstreamJobs.each{ Map thisJob ->
         set -eo pipefail
 
         git_commit="\$(git checkout "\${TAG}" && git rev-parse HEAD)"
-        revision_image=quay.io/deisci/workflow-cli-dev:"\${git_commit:0:7}"
+        revision_image=quay.io/kingdonb/workflow-cli-dev:"\${git_commit:0:7}"
 
         docker run \
           -e GCS_KEY_JSON=\""\${GCSKEY}"\" \
@@ -200,7 +200,7 @@ downstreamJobs.each{ Map thisJob ->
 
   // darwin-amd64 variants
   job("${thisJob.name}-darwin-amd64") {
-    def workdir = "golang/src/github.com/deis/workflow-cli"
+    def workdir = "golang/src/github.com/teamhephy/workflow-cli"
 
     scm {
       git {
@@ -269,13 +269,13 @@ downstreamJobs.each{ Map thisJob ->
           cd ${workdir}
 
           git_commit="\$(git checkout "\${TAG}" && git rev-parse HEAD)"
-          revision_image=quay.io/deisci/workflow-cli-dev:"\${git_commit:0:7}"
+          revision_image=quay.io/kingdonb/workflow-cli-dev:"\${git_commit:0:7}"
 
           build-darwin-cli-binary ${thisJob.target}
 
           docker run \
             -e GCS_KEY_JSON=\"\${GCSKEY}\" \
-            -v "\${GOPATH}/src/github.com/deis/workflow-cli/_dist":/workdir/_dist \
+            -v "\${GOPATH}/src/github.com/teamhephy/workflow-cli/_dist":/workdir/_dist \
             -w /workdir \
             --rm "\${revision_image}" sh -c '${upload_script}'
         """.stripIndent().trim()

--- a/jobs/workflow_docs.groovy
+++ b/jobs/workflow_docs.groovy
@@ -3,12 +3,12 @@ if (!new File("${workspace}/common.groovy").canRead()) { workspace = "${WORKSPAC
 evaluate(new File("${workspace}/common.groovy"))
 
 name = 'workflow-docs'
-downstreamJobName = 'deis-com-deploy'
+downstreamJobName = 'teamhephy-com-deploy'
 
 job(name) {
   description """
     <ol>
-      <li>Watches the <a href="https://github.com/deisthree/${name}">${name}</a> repo for a commit to master</li>
+      <li>Watches the <a href="https://github.com/teamhephy/${name}">${name}</a> repo for a commit to master</li>
       <li>Kicks off downstream ${downstreamJobName} job to deploy docs</li>
     </ol>
   """.stripIndent().trim()
@@ -16,7 +16,7 @@ job(name) {
   scm {
     git {
       remote {
-        github("deis/workflow")
+        github("teamhephy/workflow")
         credentials(defaults.github.credentialsID)
       }
       branch('${WORKFLOW_BRANCH}')
@@ -43,7 +43,7 @@ job(name) {
   }
 
   publishers {
-    downstream('deis-com-deploy', 'UNSTABLE')
+    downstream('teamhephy-com-deploy', 'UNSTABLE')
   }
 
   steps {

--- a/jobs/workflow_upgrade_test.groovy
+++ b/jobs/workflow_upgrade_test.groovy
@@ -66,7 +66,7 @@ job("${chart}-upgrade-test") {
     stringParam('HELM_VERSION', defaults.helm.version, 'Version of Helm to download/use')
     booleanParam('RUN_E2E', false, "Set to run e2e tests post-upgrade (Default: false)")
     stringParam('GINKGO_NODES', '15', "Number of parallel executors to use when running e2e tests")
-    stringParam('E2E_RUNNER_IMAGE', 'quay.io/kingdonb/e2e-runner:canary', "The e2e-runner image")
+    stringParam('E2E_RUNNER_IMAGE', 'quay.io/hephyci/e2e-runner:canary', "The e2e-runner image")
     stringParam('E2E_DIR', '/home/jenkins/workspace/$JOB_NAME/$BUILD_NUMBER', "Directory for storing workspace files")
     stringParam('E2E_DIR_LOGS', '${E2E_DIR}/logs', "Directory for storing logs. This directory is mounted into the e2e-runner container")
   }

--- a/jobs/workflow_upgrade_test.groovy
+++ b/jobs/workflow_upgrade_test.groovy
@@ -66,7 +66,7 @@ job("${chart}-upgrade-test") {
     stringParam('HELM_VERSION', defaults.helm.version, 'Version of Helm to download/use')
     booleanParam('RUN_E2E', false, "Set to run e2e tests post-upgrade (Default: false)")
     stringParam('GINKGO_NODES', '15', "Number of parallel executors to use when running e2e tests")
-    stringParam('E2E_RUNNER_IMAGE', 'quay.io/deisci/e2e-runner:canary', "The e2e-runner image")
+    stringParam('E2E_RUNNER_IMAGE', 'quay.io/kingdonb/e2e-runner:canary', "The e2e-runner image")
     stringParam('E2E_DIR', '/home/jenkins/workspace/$JOB_NAME/$BUILD_NUMBER', "Directory for storing workspace files")
     stringParam('E2E_DIR_LOGS', '${E2E_DIR}/logs', "Directory for storing logs. This directory is mounted into the e2e-runner container")
   }

--- a/repo.groovy
+++ b/repo.groovy
@@ -110,7 +110,7 @@ repos = [
     chart: 'registry',
   ],
 
-  // TODO: remove when https://github.com/deisthree/workflow/issues/766 is resolved
+  // TODO: remove when https://github.com/teamhephy/workflow/issues/766 is resolved
   [ name: 'registry-proxy',
     components: [[name: 'registry-proxy']],
     slackChannel: '#workflow',


### PR DESCRIPTION
* use 'teamhephy' github org
* quay.io/deisci becomes quay.io/kingdonb for now
* deis.com -> teamhephy.com and deis-com -> teamhephy-com
* deisthree -> teamhephy
* in some places  deis -> hephy

DOCKER_USERNAME', 'hephybot', 'Docker Hub account name'
DOCKER_EMAIL', 'dummy-address@teamhephy.com', 'Docker Hub email address'
QUAY_USERNAME', 'teamhephy+jenkins', 'Quay account name'
QUAY_EMAIL', 'XXXXXXXX@teamhephy.com', 'Quay email address'

* These may change, probably not considered stable before 2/22/2018
* (maybe even til) 3/15/2018 - plan teamhephy.com website release date

- [ ] deis.io -> teamhephy.info
- [ ] charts.teamhephy.com

* hope to have e2e validating Deis from teamhephy repos by 2/25/2018